### PR TITLE
Fix formatting in markdown lists

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -333,7 +333,7 @@ Il convertitore gestisce questi elementi Markdown:
 | **Corsivo** | `*testo*` | Testo in italics |
 | **Codice inline** | `` `codice` `` | Font Courier New |
 | **Blocchi codice** | ```` ```codice``` ```` | Paragrafo monospaziato |
-| **Liste puntate** | `- item` | Liste con bullet |
+| **Liste puntate** | `- item` | Liste con bullet (supporto grassetto/corsivo) |
 | **Liste numerate** | `1. item` | Liste numerate |
 | **Citazioni** | `> citazione` | Paragrafo indentato e corsivo |
 | **Separatori** | `---` | Linea orizzontale |

--- a/docs/project_documentation.md
+++ b/docs/project_documentation.md
@@ -332,7 +332,7 @@ Il convertitore gestisce questi elementi Markdown:
 | **Corsivo** | `*testo*` | Testo in italics |
 | **Codice inline** | `` `codice` `` | Font Courier New |
 | **Blocchi codice** | ```` ```codice``` ```` | Paragrafo monospaziato |
-| **Liste puntate** | `- item` | Liste con bullet |
+| **Liste puntate** | `- item` | Liste con bullet (supporto grassetto/corsivo) |
 | **Liste numerate** | `1. item` | Liste numerate |
 | **Citazioni** | `> citazione` | Paragrafo indentato e corsivo |
 | **Separatori** | `---` | Linea orizzontale |

--- a/server.js
+++ b/server.js
@@ -181,9 +181,13 @@ function markdownToDocx(markdownText) {
       case 'list':
         token.items.forEach((item, index) => {
           const listText = item.text.replace(/<[^>]*>/g, ''); // Rimuovi tag HTML
+          const children = [
+            new TextRun(token.ordered ? `${index + 1}. ` : '• ')
+          ];
+          parseInlineFormatting(listText, children);
           paragraphs.push(
             new Paragraph({
-              text: `${token.ordered ? `${index + 1}. ` : '• '}${listText}`,
+              children,
               indent: { left: 360 }, // Indentazione lista
             })
           );


### PR DESCRIPTION
## Summary
- parse inline formatting within markdown list items in `server.js`
- document support for bold/italic inside lists

## Testing
- `npm test` *(fails: no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_6861acf116348323a36fdb27547c70c6