### PR TITLE
Update formatNumber to handle zero values

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -933,7 +933,7 @@
         }
 
         function formatNumber(num) {
-            if (!num) return null;
+            if (num === null || num === undefined) return null;
             return new Intl.NumberFormat('it-IT').format(num);
         }
 


### PR DESCRIPTION
## Summary
- fix `formatNumber` so it doesn't treat zero as falsy

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865606040c08323816ac508475cb056