### PR TITLE
Handle missing BSR when saving books

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,6 +98,13 @@ app.post('/api/books', (req, res) => {
       const isColor = typeof (book.isColor ?? book.is_color) === 'boolean'
         ? ((book.isColor ?? book.is_color) ? 'True' : 'False')
         : (book.isColor ?? book.is_color);
+
+      const bsr = book.bsr;
+      const isBsrMissing = !bsr || bsr === 'N/A';
+      const monthlySales = isBsrMissing ? 0 : (book.monthlySales || 0);
+      const monthlyGain = isBsrMissing ? 0 : (book.monthlyGain || 0);
+      const netGain = isBsrMissing ? 0 : (book.monthlyNETGain || 0);
+
       stmt.run([
         book.asin,
         book.title,
@@ -113,16 +120,16 @@ app.post('/api/books', (req, res) => {
         book.ratings || 0,
         book.ratingAvg,
         book.publisher,
-        book.bsr || 0,
-        book.monthlySales || 0,
+        bsr || 0,
+        monthlySales,
         book.pagesnum || 0,
         book.dimensions,
         book.printCost || 0,
         book.description,
         isColor,
         book.royalties || 0,
-        book.monthlyGain || 0,
-        book.monthlyNETGain || 0
+        monthlyGain,
+        netGain
       ]);
       savedCount++;
     } catch (error) {


### PR DESCRIPTION
## Summary
- normalize monthly values when the BSR is missing in `POST /api/books`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865781f672c8323bd56f920bb0efd02