### PR TITLE
Improve Amazon data scraping

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "multer": "^1.4.5-lts.1",
     "marked": "^4.3.0",
     "docx": "^8.5.0",
-    "axios": "^1.6.7"
+    "axios": "^1.6.7",
+    "cheerio": "^1.0.0-rc.12"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
## Summary
- depend on cheerio for HTML parsing
- scrape book info with axios & cheerio
- add helper functions for rank and rating parsing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865a513b5ac83239c2201956945ce46